### PR TITLE
Add Apps Script OCR workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # insta-OCR
+
+This repository contains a sample Google Apps Script project that extracts text from images stored in Google Drive. The script converts each image into a Google Doc using Drive's OCR capabilities and appends the recognized text to another document.
+
+## Deployment
+
+1. Create a new Apps Script project or clone the contents of the `apps-script/` folder into an existing project.
+2. Copy the files from `apps-script/` into your project (`Code.js` and `appsscript.json`).
+3. In the script editor, open **Services** from the left menu and enable the **Drive API** advanced service.
+4. Set script properties `FOLDER_ID` (the Drive folder containing images) and `DOC_ID` (the document to collect OCR results).
+5. Run `installQuarterHourlyTrigger()` once to create a trigger that executes `run()` every 15 minutes. Alternatively, you can run `run()` manually.
+
+When `run()` executes, text is extracted from each image in the specified folder and appended to the destination document.

--- a/apps-script/Code.js
+++ b/apps-script/Code.js
@@ -1,0 +1,45 @@
+function extractTextFromImages(imageIds) {
+  var results = {};
+  imageIds.forEach(function(id) {
+    var file = DriveApp.getFileById(id);
+    var blob = file.getBlob();
+    var resource = {
+      title: file.getName(),
+      mimeType: 'application/vnd.google-apps.document'
+    };
+    var docFile = Drive.Files.insert(resource, blob, {ocr: true});
+    var doc = DocumentApp.openById(docFile.id);
+    results[id] = doc.getBody().getText();
+    Drive.Files.remove(docFile.id);
+  });
+  return results;
+}
+
+function installQuarterHourlyTrigger() {
+  ScriptApp.newTrigger('run').timeBased().everyMinutes(15).create();
+}
+
+function run() {
+  var folderId = PropertiesService.getScriptProperties().getProperty('FOLDER_ID');
+  var docId = PropertiesService.getScriptProperties().getProperty('DOC_ID');
+  if (!folderId || !docId) {
+    throw new Error('FOLDER_ID and DOC_ID must be set in script properties.');
+  }
+  var folder = DriveApp.getFolderById(folderId);
+  var files = folder.getFiles();
+  var imageIds = [];
+  while (files.hasNext()) {
+    var f = files.next();
+    if (f.getMimeType().match('image/')) {
+      imageIds.push(f.getId());
+    }
+  }
+  var texts = extractTextFromImages(imageIds);
+  var doc = DocumentApp.openById(docId);
+  var body = doc.getBody();
+  Object.keys(texts).forEach(function(id) {
+    body.appendParagraph('Text extracted from file ID: ' + id);
+    body.appendParagraph(texts[id]);
+    body.appendHorizontalRule();
+  });
+}

--- a/apps-script/appsscript.json
+++ b/apps-script/appsscript.json
@@ -1,0 +1,15 @@
+{
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/script.scriptapp"
+  ],
+  "dependencies": {
+    "enabledAdvancedServices": [{
+      "userSymbol": "Drive",
+      "serviceId": "drive",
+      "version": "v2"
+    }]
+  }
+}


### PR DESCRIPTION
## Summary
- add Google Apps Script example with OCR workflow
- document how to deploy the script

## Testing
- `bash -lc 'ls'`
